### PR TITLE
Pass additional params only if not empty

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -15,7 +15,12 @@ function play_video(url) {
 	var process = Cc["@mozilla.org/process/util;1"].createInstance(Ci.nsIProcess);
 	process.init(file);
 
-	var args = simple_prefs.prefs.params.split(" ");
+	var params = simple_prefs.prefs.params;
+
+	if (params)
+	    var args = params.split(" ");
+    else
+        var args = [];
 
 	args.push(url);
 	


### PR DESCRIPTION
Currently if `params` is empty, it is still split and passed onto the player. This causes `mpv`  to attempt to open  a `''`  file:

```
JPM [info] Starting jpm run on mpv-youtube-dl-binding
JPM [info] Creating a new profile
Playing: 
[file] Cannot open file '': No such file or directory
Failed to open .
...
```

This PR fixes this by only spliting and passing `params` if it is not empty.